### PR TITLE
Fix CryptoCompare symbol parsing

### DIFF
--- a/App.js
+++ b/App.js
@@ -131,42 +131,51 @@ export default function App() {
       const symbols = tradables.map(a => a.symbol).join(',');
 
       const snapRes = await fetch(
-        `${DATA_BASE_URL}/bars?symbols=${symbols}&timeframe=1Day&limit=1`,
+        `${DATA_BASE_URL}/snapshots?symbols=${symbols}`,
         { headers: HEADERS }
       );
       const snapData = await snapRes.json();
 
       const ranked = await Promise.all(
         tradables.map(async a => {
-          const info = snapData[a.symbol] && snapData[a.symbol][0];
-          if (info) {
-            const vol = info.v || 0;
-            const volat = info.h && info.l ? (info.h - info.l) / info.c : 0;
-            return { name: a.name, symbol: a.symbol, vol, volat };
+          let bar = snapData[a.symbol]?.latestBar || null;
+
+          if (!bar) {
+            try {
+              const barsRes = await fetch(
+                `${DATA_BASE_URL}/bars?symbols=${a.symbol}&timeframe=15Min&limit=1`,
+                { headers: HEADERS }
+              );
+              const barsData = await barsRes.json();
+              bar = barsData[a.symbol]?.[0] || null;
+            } catch {
+              bar = null;
+            }
           }
-          try {
-            const barsRes = await fetch(
-              `${DATA_BASE_URL}/bars?symbols=${a.symbol}&timeframe=15Min&limit=5`,
-              { headers: HEADERS }
-            );
-            const barsData = await barsRes.json();
-            const bars = barsData[a.symbol] || [];
-            const highs = bars.map(b => b.h || 0);
-            const lows = bars.map(b => b.l || 0);
-            const closes = bars.map(b => b.c || 0);
-            const hi = Math.max(...highs);
-            const lo = Math.min(...lows);
-            const last = closes.at(-1) || 1;
-            const volat = hi && lo ? (hi - lo) / last : 0;
-            return { name: a.name, symbol: a.symbol, vol: 0, volat };
-          } catch {
-            return { name: a.name, symbol: a.symbol, vol: 0, volat: 0 };
+
+          if (!bar || bar.h == null || bar.l == null || bar.c == null) {
+            console.log('Skipping asset due to missing bar data:', a.symbol);
+            return null;
           }
+
+          const volume = bar.v || 0;
+          const volat = (bar.h - bar.l) / bar.c;
+          if (!volume || !isFinite(volat)) {
+            console.log('Skipping asset due to invalid data:', a.symbol);
+            return null;
+          }
+
+          return { name: a.name, symbol: a.symbol, vol: volume, volat };
         })
       );
 
-      ranked.sort((b, a) => (a.vol || a.volat) - (b.vol || b.volat));
-      setTracked(ranked.slice(0, 20));
+      const valid = ranked.filter(Boolean).sort((a, b) => b.volat - a.volat);
+
+      if (valid.length < 10) {
+        Alert.alert('Data Issue', `Only ${valid.length} assets have valid volatility`);
+      }
+
+      setTracked(valid.slice(0, 20));
       setAssetError(null);
     } catch (err) {
       console.error('asset load failed', err);
@@ -184,28 +193,29 @@ export default function App() {
       tracked.map(async asset => {
         try {
           const pair = asset.symbol.toUpperCase();
-          const isUsd = pair.endsWith('USD') || pair.endsWith('/USD');
-          if (!isUsd) {
-            return { ...asset, error: 'Unsupported pair' };
+          const match = pair.match(/^([^\/]+)\/USD$/);
+          if (!match) {
+            return { ...asset, error: '⚠️ Not supported on CryptoCompare' };
           }
-          const base = pair.replace('/USD', '').replace('USD', '');
+          const base = match[1];
 
-          const priceRes = await fetch(
-            `https://min-api.cryptocompare.com/data/price?fsym=${base}&tsyms=USD`
-          );
+          const priceUrl = `https://min-api.cryptocompare.com/data/price?fsym=${base}&tsyms=USD`;
+          console.log('Price URL:', priceUrl);
+          const priceRes = await fetch(priceUrl);
           const priceData = await priceRes.json();
           const price = priceData.USD;
 
-          const histoRes = await fetch(
-            `https://min-api.cryptocompare.com/data/v2/histominute?fsym=${base}&tsym=USD&limit=52&aggregate=15`
-          );
+          const histoUrl = `https://min-api.cryptocompare.com/data/v2/histominute?fsym=${base}&tsym=USD&limit=52&aggregate=15`;
+          console.log('Histo URL:', histoUrl);
+          const histoRes = await fetch(histoUrl);
           const histoData = await histoRes.json();
 
-          if (!histoData?.Data || !histoData.Data?.Data) {
+          const bars = Array.isArray(histoData?.Data?.Data) ? histoData.Data.Data : null;
+          if (!bars || bars.length < 20) {
             return { ...asset, error: 'No historical data' };
           }
 
-          const closes = histoData.Data.Data.map(bar => bar.close);
+          const closes = bars.map(bar => bar.close).filter(c => c != null);
 
           const rsi = calcRSI(closes);
           const prevRsi = calcRSI(closes.slice(0, -1));
@@ -247,7 +257,9 @@ export default function App() {
       if (b.watchlist) return 1;
       return 0;
     });
-    setData(sorted);
+
+    const valid = sorted.filter(a => !a.error).slice(0, 20);
+    setData(valid);
     setRefreshing(false);
   };
 

--- a/frontend/App.js
+++ b/frontend/App.js
@@ -131,42 +131,51 @@ export default function App() {
       const symbols = tradables.map(a => a.symbol).join(',');
 
       const snapRes = await fetch(
-        `${DATA_BASE_URL}/bars?symbols=${symbols}&timeframe=1Day&limit=1`,
+        `${DATA_BASE_URL}/snapshots?symbols=${symbols}`,
         { headers: HEADERS }
       );
       const snapData = await snapRes.json();
 
       const ranked = await Promise.all(
         tradables.map(async a => {
-          const info = snapData[a.symbol] && snapData[a.symbol][0];
-          if (info) {
-            const vol = info.v || 0;
-            const volat = info.h && info.l ? (info.h - info.l) / info.c : 0;
-            return { name: a.name, symbol: a.symbol, vol, volat };
+          let bar = snapData[a.symbol]?.latestBar || null;
+
+          if (!bar) {
+            try {
+              const barsRes = await fetch(
+                `${DATA_BASE_URL}/bars?symbols=${a.symbol}&timeframe=15Min&limit=1`,
+                { headers: HEADERS }
+              );
+              const barsData = await barsRes.json();
+              bar = barsData[a.symbol]?.[0] || null;
+            } catch {
+              bar = null;
+            }
           }
-          try {
-            const barsRes = await fetch(
-              `${DATA_BASE_URL}/bars?symbols=${a.symbol}&timeframe=15Min&limit=5`,
-              { headers: HEADERS }
-            );
-            const barsData = await barsRes.json();
-            const bars = barsData[a.symbol] || [];
-            const highs = bars.map(b => b.h || 0);
-            const lows = bars.map(b => b.l || 0);
-            const closes = bars.map(b => b.c || 0);
-            const hi = Math.max(...highs);
-            const lo = Math.min(...lows);
-            const last = closes.at(-1) || 1;
-            const volat = hi && lo ? (hi - lo) / last : 0;
-            return { name: a.name, symbol: a.symbol, vol: 0, volat };
-          } catch {
-            return { name: a.name, symbol: a.symbol, vol: 0, volat: 0 };
+
+          if (!bar || bar.h == null || bar.l == null || bar.c == null) {
+            console.log('Skipping asset due to missing bar data:', a.symbol);
+            return null;
           }
+
+          const volume = bar.v || 0;
+          const volat = (bar.h - bar.l) / bar.c;
+          if (!volume || !isFinite(volat)) {
+            console.log('Skipping asset due to invalid data:', a.symbol);
+            return null;
+          }
+
+          return { name: a.name, symbol: a.symbol, vol: volume, volat };
         })
       );
 
-      ranked.sort((b, a) => (a.vol || a.volat) - (b.vol || b.volat));
-      setTracked(ranked.slice(0, 20));
+      const valid = ranked.filter(Boolean).sort((a, b) => b.volat - a.volat);
+
+      if (valid.length < 10) {
+        Alert.alert('Data Issue', `Only ${valid.length} assets have valid volatility`);
+      }
+
+      setTracked(valid.slice(0, 20));
       setAssetError(null);
     } catch (err) {
       console.error('asset load failed', err);
@@ -184,28 +193,29 @@ export default function App() {
       tracked.map(async asset => {
         try {
           const pair = asset.symbol.toUpperCase();
-          const isUsd = pair.endsWith('USD') || pair.endsWith('/USD');
-          if (!isUsd) {
-            return { ...asset, error: 'Unsupported pair' };
+          const match = pair.match(/^([^\/]+)\/USD$/);
+          if (!match) {
+            return { ...asset, error: '⚠️ Not supported on CryptoCompare' };
           }
-          const base = pair.replace('/USD', '').replace('USD', '');
+          const base = match[1];
 
-          const priceRes = await fetch(
-            `https://min-api.cryptocompare.com/data/price?fsym=${base}&tsyms=USD`
-          );
+          const priceUrl = `https://min-api.cryptocompare.com/data/price?fsym=${base}&tsyms=USD`;
+          console.log('Price URL:', priceUrl);
+          const priceRes = await fetch(priceUrl);
           const priceData = await priceRes.json();
           const price = priceData.USD;
 
-          const histoRes = await fetch(
-            `https://min-api.cryptocompare.com/data/v2/histominute?fsym=${base}&tsym=USD&limit=52&aggregate=15`
-          );
+          const histoUrl = `https://min-api.cryptocompare.com/data/v2/histominute?fsym=${base}&tsym=USD&limit=52&aggregate=15`;
+          console.log('Histo URL:', histoUrl);
+          const histoRes = await fetch(histoUrl);
           const histoData = await histoRes.json();
 
-          if (!histoData?.Data || !histoData.Data?.Data) {
+          const bars = Array.isArray(histoData?.Data?.Data) ? histoData.Data.Data : null;
+          if (!bars || bars.length < 20) {
             return { ...asset, error: 'No historical data' };
           }
 
-          const closes = histoData.Data.Data.map(bar => bar.close);
+          const closes = bars.map(bar => bar.close).filter(c => c != null);
 
           const rsi = calcRSI(closes);
           const prevRsi = calcRSI(closes.slice(0, -1));
@@ -247,7 +257,9 @@ export default function App() {
       if (b.watchlist) return 1;
       return 0;
     });
-    setData(sorted);
+
+    const valid = sorted.filter(a => !a.error).slice(0, 20);
+    setData(valid);
     setRefreshing(false);
   };
 


### PR DESCRIPTION
## Summary
- clean up CryptoCompare symbol extraction to only allow `/USD` pairs
- log request URLs
- guard against missing/short data
- filter output so only up to 20 valid tokens render
- rank Alpaca assets by recent volatility and alert when too few tokens are available

## Testing
- `npm test --silent`
- `npm test --silent` in `/frontend`


------
https://chatgpt.com/codex/tasks/task_e_687d9e034b4c8325ae6a47e554ff2dce