### PR TITLE
Add dynamic Alpaca asset fetch

### DIFF
--- a/App.js
+++ b/App.js
@@ -18,13 +18,14 @@ const HEADERS = {
 
 const DATA_BASE_URL = 'https://data.alpaca.markets/v1beta1/crypto';
 
-// Fixed list of supported USD crypto pairs
+// Fixed list of supported USD crypto pairs for analytics display
 const DEFAULT_TOKENS = [
   "BTC/USD", "ETH/USD", "SOL/USD", "LTC/USD", "BCH/USD",
   "DOGE/USD", "AVAX/USD", "ADA/USD", "UNI/USD", "MATIC/USD",
   "LINK/USD", "AAVE/USD", "COMP/USD", "XLM/USD", "DOT/USD",
   "FIL/USD", "ETC/USD", "ALGO/USD", "ATOM/USD", "MKR/USD"
 ];
+
 
 export default function App() {
   const pendingSales = {};
@@ -34,6 +35,7 @@ export default function App() {
   const [darkMode, setDarkMode] = useState(false);
   const [autoTrade, setAutoTrade] = useState(false);
   const [accountCash, setAccountCash] = useState(0);
+  const [tradableTokens, setTradableTokens] = useState([]);
 
   const calcRSI = (closes, period = 14) => {
     if (closes.length < period + 1) return null;
@@ -86,6 +88,23 @@ export default function App() {
       return parseFloat(data.cash || 0);
     } catch {
       return 0;
+    }
+  };
+
+  const fetchTradableTokens = async () => {
+    try {
+      const res = await fetch(
+        `${ALPACA_BASE_URL}/assets?asset_class=crypto`,
+        { headers: HEADERS }
+      );
+      const assets = await res.json();
+      const tokens = Array.isArray(assets)
+        ? assets.filter(a => a.tradable).map(a => a.symbol)
+        : [];
+      setTradableTokens(tokens);
+    } catch (err) {
+      console.error('Failed to fetch tradable tokens', err);
+      setTradableTokens([]);
     }
   };
 
@@ -150,6 +169,10 @@ export default function App() {
   };
 
   const placeOrder = async (symbol, isAuto = false) => {
+    if (!tradableTokens.includes(symbol)) {
+      Alert.alert('❌ Trade Unsupported', `Alpaca does not support trading ${symbol}`);
+      return;
+    }
     try {
       const cash = await fetchAccountCash();
       const tradeDollars = cash * TRADE_FRACTION;
@@ -171,10 +194,11 @@ export default function App() {
 
 
   const loadAssets = async () => {
-    // Use fixed list of supported tokens with simple name mapping
+    // Map default tokens and mark whether Alpaca allows trading
     const assets = DEFAULT_TOKENS.map(sym => ({
       symbol: sym,
-      name: sym.split('/')[0]
+      name: sym.split('/')[0],
+      tradable: tradableTokens.includes(sym)
     }));
     setTracked(assets);
   };
@@ -261,10 +285,14 @@ export default function App() {
   };
 
   useEffect(() => {
-    loadAssets();
-    const assetInterval = setInterval(loadAssets, 3600000);
-    return () => clearInterval(assetInterval);
+    fetchTradableTokens();
+    const interval = setInterval(fetchTradableTokens, 3600000);
+    return () => clearInterval(interval);
   }, []);
+
+  useEffect(() => {
+    loadAssets();
+  }, [tradableTokens]);
 
   useEffect(() => {
     if (tracked.length === 0) return;
@@ -275,8 +303,7 @@ export default function App() {
 
   const onRefresh = () => {
     setRefreshing(true);
-    loadAssets();
-    loadData();
+    fetchTradableTokens();
   };
 
   const renderCard = (asset) => {
@@ -293,6 +320,9 @@ export default function App() {
           <Text style={styles.error}>Error: {asset.error}</Text>
         ) : (
           <>
+            {!asset.tradable && (
+              <Text style={styles.warning}>⚠️ Not Tradable</Text>
+            )}
             <Text>Price: ${asset.price}</Text>
             <Text>RSI: {asset.rsi} | MACD: {asset.macd} | Signal: {asset.signal}</Text>
             <Text>Trend: {asset.trend}</Text>
@@ -339,6 +369,7 @@ const styles = StyleSheet.create({
   },
   symbol: { fontSize: 15, fontWeight: 'bold', color: '#005eff' },
   error: { color: 'red', fontSize: 12 },
+  warning: { color: '#FFA500', fontSize: 12 },
   buyButton: { color: '#0066cc', marginTop: 8, fontWeight: 'bold' },
   buyButtonDisabled: { color: '#999', marginTop: 8, fontWeight: 'bold' },
 });


### PR DESCRIPTION
## Summary
- fetch crypto assets from Alpaca at startup
- mark tokens with `tradable` flag based on live Alpaca data
- block trades for unsupported tokens
- warn on cards when a token isn't tradable

## Testing
- `npm test` *(fails: Missing script)*
- `npm --prefix frontend test`

------
https://chatgpt.com/codex/tasks/task_e_687ebafb693883259d75cadbcabca8d8