### PR TITLE
Allow manual buys regardless of entry logic

### DIFF
--- a/frontend/App.js
+++ b/frontend/App.js
@@ -123,7 +123,7 @@ export default function App() {
         rsi > 30 &&
         (trend === '⬆️' || trend === '🟰');
 
-      if (!shouldBuy) {
+      if (!shouldBuy && !isManual) {
         console.log(`Entry conditions not met for ${symbol}`);
         return;
       }


### PR DESCRIPTION
## Summary
- adjust `placeOrder` to skip signal checks when manual trades are triggered

## Testing
- `npm test` *(fails: Missing script)*
- `npm test` in frontend *(fails: Missing script)*
- `npm test` in backend *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68826f2675948325b335dab309654c05