### PR TITLE
Add sequential limit trade function

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1,12 +1,25 @@
 require('dotenv').config();
 const express = require('express');
 const axios = require('axios');
+const { placeLimitBuyThenSell } = require('./trade');
 const app = express();
 app.use(express.json());
 
 const ALPACA_BASE_URL = 'https://paper-api.alpaca.markets/v2';
 const API_KEY = process.env.ALPACA_API_KEY;
 const SECRET_KEY = process.env.ALPACA_SECRET_KEY;
+
+// Sequentially place a limit buy order followed by a limit sell once filled
+app.post('/trade', async (req, res) => {
+  const { symbol, qty, limit_price } = req.body;
+  try {
+    const result = await placeLimitBuyThenSell(symbol, qty, limit_price);
+    res.json(result);
+  } catch (err) {
+    console.error('Trade error:', err?.response?.data || err.message);
+    res.status(500).json({ error: err.message });
+  }
+});
 
 app.post('/buy', async (req, res) => {
   const { symbol, qty, side, type, time_in_force, limit_price } = req.body;

--- a/backend/trade.js
+++ b/backend/trade.js
@@ -1,0 +1,68 @@
+const axios = require('axios');
+
+const ALPACA_BASE_URL = 'https://paper-api.alpaca.markets/v2';
+const API_KEY = process.env.ALPACA_API_KEY;
+const SECRET_KEY = process.env.ALPACA_SECRET_KEY;
+
+const HEADERS = {
+  'APCA-API-KEY-ID': API_KEY,
+  'APCA-API-SECRET-KEY': SECRET_KEY,
+};
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Places a limit buy order first, then a limit sell after the buy is filled.
+async function placeLimitBuyThenSell(symbol, qty, limitPrice) {
+  // submit the limit buy order
+  const buyRes = await axios.post(
+    `${ALPACA_BASE_URL}/orders`,
+    {
+      symbol,
+      qty,
+      side: 'buy',
+      type: 'limit',
+      time_in_force: 'gtc',
+      limit_price: limitPrice,
+    },
+    { headers: HEADERS }
+  );
+
+  const buyOrder = buyRes.data;
+
+  // poll until the order is filled
+  let filledOrder = buyOrder;
+  for (let i = 0; i < 20; i++) {
+    const check = await axios.get(`${ALPACA_BASE_URL}/orders/${buyOrder.id}`, {
+      headers: HEADERS,
+    });
+    filledOrder = check.data;
+    if (filledOrder.status === 'filled') break;
+    await sleep(3000);
+  }
+
+  if (filledOrder.status !== 'filled') {
+    throw new Error('Buy order not filled in time');
+  }
+
+  const avgPrice = parseFloat(filledOrder.filled_avg_price);
+  const sellPrice = (avgPrice * 1.005).toFixed(2);
+
+  const sellRes = await axios.post(
+    `${ALPACA_BASE_URL}/orders`,
+    {
+      symbol,
+      qty: filledOrder.filled_qty,
+      side: 'sell',
+      type: 'limit',
+      time_in_force: 'gtc',
+      limit_price: sellPrice,
+    },
+    { headers: HEADERS }
+  );
+
+  return { buy: filledOrder, sell: sellRes.data };
+}
+
+module.exports = { placeLimitBuyThenSell };


### PR DESCRIPTION
## Summary
- create `trade.js` with sequential limit buy/sell logic
- expose a `/trade` endpoint that uses the new function

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6882d44acc848325a8a9dfc60b15baec