### PR TITLE
Fix null data rendering crash

### DIFF
--- a/frontend/App.js
+++ b/frontend/App.js
@@ -309,7 +309,8 @@ export default function App() {
         }
       })
     );
-    setData(results);
+    // Filter out null/undefined entries to avoid crashing renderCard
+    setData(results.filter(Boolean));
     setRefreshing(false);
   };
 


### PR DESCRIPTION
## Summary
- filter out null entries before updating state in frontend

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68839483fe2c8325aceea937f5a49324