### PR TITLE
Update buy logic and sell target

### DIFF
--- a/backend/trade.js
+++ b/backend/trade.js
@@ -49,7 +49,7 @@ async function placeLimitBuyThenSell(symbol, qty, limitPrice) {
   }
 
   const avgPrice = parseFloat(filledOrder.filled_avg_price);
-  const sellPrice = (avgPrice * 1.005).toFixed(2);
+  const sellPrice = (avgPrice * 1.0025).toFixed(2);
 
   const sellRes = await axios.post(
     `${ALPACA_BASE_URL}/orders`,
@@ -95,7 +95,7 @@ function roundPrice(price) {
   return parseFloat(Number(price).toFixed(2));
 }
 
-// Market buy using 10% of cash then place a limit sell 0.5% higher
+// Market buy using 10% of cash then place a limit sell 0.25% higher
 async function placeMarketBuyThenSell(symbol) {
   const [price, cash] = await Promise.all([
     getLatestPrice(symbol),
@@ -139,7 +139,7 @@ async function placeMarketBuyThenSell(symbol) {
   // Wait 10 seconds before selling
   await sleep(10000);
 
-  const limitPrice = roundPrice(parseFloat(filled.filled_avg_price) * 1.005);
+  const limitPrice = roundPrice(parseFloat(filled.filled_avg_price) * 1.0025);
 
   try {
     const sellRes = await axios.post(

--- a/frontend/App.js
+++ b/frontend/App.js
@@ -146,7 +146,11 @@ export default function App() {
       const pricePrev = closes[closes.length - 2];
       const emaBreakout = ema != null && emaPrev != null && price > ema && pricePrev < emaPrev;
 
-      const shouldBuy = macd != null && signal != null && macd > signal && rsiRising && emaBreakout;
+      const shouldBuy =
+        macd != null &&
+        signal != null &&
+        macd > signal &&
+        (rsiRising || emaBreakout);
 
       if (!shouldBuy && !isManual) {
         console.log(`Entry conditions not met for ${symbol}`);

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -4,11 +4,10 @@ This React Native app displays crypto tokens with entry signals and lets you pla
 
 ## Entry Logic
 
-Tokens are flagged **ENTRY READY** when all of the following are true:
+Tokens are flagged **ENTRY READY** when the MACD line is above the signal line, and either:
 
-1. The MACD line has crossed above the signal line.
-2. The RSI is above 50 and rising compared to the previous candle.
-3. Price has broken out above the 10 period EMA after being below it on the prior candle.
+1. The RSI is rising above 30 compared to the previous candle, **or**
+2. Price breaks above the 10 period EMA after being below it on the prior candle.
 
 If the MACD is bullish but the other conditions are not yet met, the token appears on the **WATCHLIST**.
 


### PR DESCRIPTION
## Summary
- relax automated buy conditions in `placeOrder`
- reduce sell profit target from 0.5% to 0.25%
- document the new entry logic

## Testing
- `npm -v`


------
https://chatgpt.com/codex/tasks/task_e_68839f3882bc8325adeeb9fda8064fe3