### PR TITLE
Relax entry conditions

### DIFF
--- a/frontend/App.js
+++ b/frontend/App.js
@@ -147,10 +147,9 @@ export default function App() {
       const emaBreakout = ema != null && emaPrev != null && price > ema && pricePrev < emaPrev;
 
       const shouldBuy =
-        macd != null &&
-        signal != null &&
-        macd > signal &&
-        (rsiRising || emaBreakout);
+        (macd != null && signal != null && macd > signal) ||
+        rsiRising ||
+        trend === '⬆️';
 
       if (!shouldBuy && !isManual) {
         console.log(`Entry conditions not met for ${symbol}`);
@@ -286,11 +285,9 @@ export default function App() {
           const trend = getTrendSymbol(closes);
 
           const entryReady =
-            macd != null &&
-            signal != null &&
-            macd > signal &&
-            rsiRising &&
-            (trend === '⬆️' || trend === '🟰');
+            (macd != null && signal != null && macd > signal) ||
+            rsiRising ||
+            trend === '⬆️';
 
           const watchlist = macd != null && signal != null && macd > signal && !entryReady;
 


### PR DESCRIPTION
## Summary
- loosen the buy check in placeOrder
- match entryReady logic to new aggressive strategy

## Testing
- `npm test --silent` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_6883a4710b148325ae33575b09f7e99e