### PR TITLE
Remove stablecoins from token list

### DIFF
--- a/frontend/App.js
+++ b/frontend/App.js
@@ -38,8 +38,6 @@ const ORIGINAL_TOKENS = [
   { name: 'XTZ/USD', symbol: 'XTZUSD', cc: 'XTZ' },
   { name: 'YFI/USD', symbol: 'YFIUSD', cc: 'YFI' },
   { name: 'GRT/USD', symbol: 'GRTUSD', cc: 'GRT' },
-  { name: 'USDC/USD', symbol: 'USDCUSD', cc: 'USDC' },
-  { name: 'USDT/USD', symbol: 'USDTUSD', cc: 'USDT' },
   { name: 'MKR/USD', symbol: 'MKRUSD', cc: 'MKR' },
 ];
 


### PR DESCRIPTION
## Summary
- remove USDC/USD and USDT/USD from the predefined token list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883ae17c07083258d0274116bbd71f3