### PR TITLE
Fix time_in_force and update tokens

### DIFF
--- a/backend/trade.js
+++ b/backend/trade.js
@@ -24,8 +24,8 @@ async function placeLimitBuyThenSell(symbol, qty, limitPrice) {
       qty,
       side: 'buy',
       type: 'limit',
-      // use a simple day order so it works for crypto
-      time_in_force: 'day',
+      // crypto orders must be GTC
+      time_in_force: 'gtc',
       limit_price: limitPrice,
     },
     { headers: HEADERS }
@@ -58,8 +58,8 @@ async function placeLimitBuyThenSell(symbol, qty, limitPrice) {
       qty: filledOrder.filled_qty,
       side: 'sell',
       type: 'limit',
-      // match the buy order's day time in force
-      time_in_force: 'day',
+      // match the buy order's time in force
+      time_in_force: 'gtc',
       limit_price: sellPrice,
     },
     { headers: HEADERS }
@@ -114,7 +114,7 @@ async function placeMarketBuyThenSell(symbol) {
       qty,
       side: 'buy',
       type: 'market',
-      time_in_force: 'day',
+      time_in_force: 'gtc',
     },
     { headers: HEADERS }
   );
@@ -149,7 +149,7 @@ async function placeMarketBuyThenSell(symbol) {
         qty: filled.filled_qty,
         side: 'sell',
         type: 'limit',
-        time_in_force: 'day',
+        time_in_force: 'gtc',
         limit_price: limitPrice,
       },
       { headers: HEADERS }

--- a/frontend/App.js
+++ b/frontend/App.js
@@ -39,6 +39,8 @@ const ORIGINAL_TOKENS = [
   { name: 'YFI/USD', symbol: 'YFIUSD', cc: 'YFI' },
   { name: 'GRT/USD', symbol: 'GRTUSD', cc: 'GRT' },
   { name: 'MKR/USD', symbol: 'MKRUSD', cc: 'MKR' },
+  { name: 'USDC/USD', symbol: 'USDCUSD', cc: 'USDC' },
+  { name: 'USDT/USD', symbol: 'USDTUSD', cc: 'USDT' },
 ];
 
 export default function App() {
@@ -154,7 +156,7 @@ export default function App() {
         qty,
         side: 'buy',
         type: 'market',
-        time_in_force: 'day',
+        time_in_force: 'gtc',
       };
 
       const res = await fetch(`${ALPACA_BASE_URL}/orders`, {
@@ -206,7 +208,7 @@ export default function App() {
         qty: filledOrder.filled_qty,
         side: 'sell',
         type: 'limit',
-        time_in_force: 'day',
+        time_in_force: 'gtc',
         limit_price: (sellBasis * 1.0025).toFixed(2),
       };
 


### PR DESCRIPTION
## Summary
- ensure crypto orders use `time_in_force: 'gtc'`
- extend token list to include USDC and USDT

## Testing
- `npm test` (fails: Missing script)

------
https://chatgpt.com/codex/tasks/task_e_6883b075757883258190db04b1a0f1b7