### PR TITLE
Fix token display and trading logic

### DIFF
--- a/frontend/App.js
+++ b/frontend/App.js
@@ -114,7 +114,11 @@ export default function App() {
         `https://min-api.cryptocompare.com/data/price?fsym=${ccSymbol}&tsyms=USD`
       );
       const priceData = await priceRes.json();
-      const price = priceData.USD;
+      const price = typeof priceData.USD === 'number' ? priceData.USD : null;
+      if (price == null) {
+        console.warn(`Price unavailable for ${ccSymbol}`);
+        return;
+      }
 
       const histoRes = await fetch(
         `https://min-api.cryptocompare.com/data/v2/histominute?fsym=${ccSymbol}&tsym=USD&limit=52&aggregate=15`
@@ -125,7 +129,9 @@ export default function App() {
         : null;
       if (!histoBars) {
         console.warn(`No chart data returned for ${ccSymbol}`);
-        return;
+        if (!isManual) {
+          return;
+        }
       }
       const closes = Array.isArray(histoBars)
         ? histoBars.map((bar) => bar.close)
@@ -203,6 +209,8 @@ export default function App() {
       const sellBasis = isNaN(filledPrice) ? price : filledPrice;
 
       Alert.alert('✅ Buy Filled', `Bought ${symbol} at $${sellBasis.toFixed(2)}`);
+
+      await sleep(10000);
 
       const limitSell = {
         symbol,

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -4,12 +4,7 @@ This React Native app displays crypto tokens with entry signals and lets you pla
 
 ## Entry Logic
 
-Tokens are flagged **ENTRY READY** when the MACD line is above the signal line, and either:
-
-1. The RSI is rising above 30 compared to the previous candle, **or**
-2. Price breaks above the 10 period EMA after being below it on the prior candle.
-
-If the MACD is bullish but the other conditions are not yet met, the token appears on the **WATCHLIST**.
+Tokens are flagged **ENTRY READY** when the MACD line is above the signal line. If the MACD is rising but has not crossed, the token appears on the **WATCHLIST**. Other indicators are ignored for entry decisions.
 
 ## Setup
 


### PR DESCRIPTION
## Summary
- improve handling of missing chart data when placing orders
- abort if price data is unavailable
- wait 10 seconds after buy fill before placing limit sell
- update readme to reflect simplified entry logic

## Testing
- `npm test --silent` (no tests found)

------
https://chatgpt.com/codex/tasks/task_e_6883c2710c988325878ec67e29555ce8