### PR TITLE
Handle low cash silently

### DIFF
--- a/frontend/App.js
+++ b/frontend/App.js
@@ -151,8 +151,8 @@ export default function App() {
       const accountData = await accountRes.json();
       const buyingPower = parseFloat(accountData.buying_power || accountData.cash || '0');
       const qty = parseFloat(((buyingPower * 0.1) / price).toFixed(6));
+      // Skip buy silently if not enough cash
       if (qty <= 0) {
-        console.error('❌ Insufficient buying power');
         return;
       }
 


### PR DESCRIPTION
## Summary
- improve `placeOrder` to silently skip buys when cash is too low

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6883cf643a708325ba51054dc15eca45