### PR TITLE
Fix crypto sell order TIF

### DIFF
--- a/frontend/App.js
+++ b/frontend/App.js
@@ -210,14 +210,14 @@ export default function App() {
 
       Alert.alert('✅ Buy Filled', `Bought ${symbol} at $${sellBasis.toFixed(2)}`);
 
-      await sleep(10000);
+      await sleep(15000);
 
       const limitSell = {
         symbol,
         qty: filledOrder.filled_qty,
         side: 'sell',
         type: 'limit',
-        time_in_force: 'fok',
+        time_in_force: 'gtc',
         order_class: 'simple',
         extended_hours: true,
         limit_price: (sellBasis * 1.0025).toFixed(2),


### PR DESCRIPTION
## Summary
- use `time_in_force: 'gtc'` for crypto limit sells
- wait 15 seconds before placing limit sell after a buy

## Testing
- `npm test` in `frontend` *(fails: Missing script)*
- `npm test` in `backend` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6883d373c4e4832585ef2a3aaef5ed19