### PR TITLE
Update buy order time in force

### DIFF
--- a/frontend/App.js
+++ b/frontend/App.js
@@ -174,7 +174,7 @@ export default function App() {
         qty,
         side: 'buy',
         type: 'market',
-        time_in_force: 'gtc',
+        time_in_force: 'ioc',
         order_class: 'simple',
         extended_hours: true,
       };


### PR DESCRIPTION
## Summary
- set the time in force for market buy orders to `ioc`

## Testing
- `grep -n time_in_force frontend/App.js`

------
https://chatgpt.com/codex/tasks/task_e_6883f7055c048325a862c41e1b482699