### PR TITLE
Enforce $10 minimum trade cost

### DIFF
--- a/backend/trade.js
+++ b/backend/trade.js
@@ -102,7 +102,12 @@ async function placeMarketBuyThenSell(symbol) {
     getAccountCash(),
   ]);
 
-  const qty = roundQty((cash * 0.1) / price);
+  if (cash < 10) {
+    throw new Error('Insufficient cash for trade');
+  }
+
+  const allocation = Math.min(Math.max(cash * 0.1, 10), cash);
+  const qty = roundQty(allocation / price);
   if (qty <= 0) {
     throw new Error('Insufficient cash for trade');
   }

--- a/frontend/App.js
+++ b/frontend/App.js
@@ -157,7 +157,22 @@ export default function App() {
       const accountRes = await fetch(`${ALPACA_BASE_URL}/account`, { headers: HEADERS });
       const accountData = await accountRes.json();
       const cash = parseFloat(accountData.cash || '0');
-      let qty = parseFloat(((cash * 0.1) / price).toFixed(6));
+
+      if (cash < 10) {
+        if (isManual) {
+          Toast.show('❌ Order Failed: Insufficient cash', {
+            duration: Toast.durations.SHORT,
+            position: Toast.positions.BOTTOM,
+          });
+        } else {
+          insufficientFundsThisCycle = true;
+          console.log('Insufficient funds, skipping remaining buys this cycle');
+        }
+        return;
+      }
+
+      const allocation = Math.min(Math.max(cash * 0.1, 10), cash);
+      let qty = parseFloat((allocation / price).toFixed(6));
       if (qty * price > cash) {
         qty = parseFloat((cash / price).toFixed(6));
       }


### PR DESCRIPTION
## Summary
- ensure frontend and backend skip orders when available cash is under $10
- allocate at least $10 per order even when 10% of cash is lower

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6884102b56748325973721a815fb37a0