### PR TITLE
Add overlay notification system

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -8,9 +8,9 @@ Tokens are flagged **ENTRY READY** when the MACD line is above the signal line. 
 
 ## Setup
 
-1. `npm install` (installs dependencies including `react-native-root-toast`)
+1. `npm install`
 2. Copy `.env.example` to `.env`
 3. Start backend (Node.js Express server)
 4. Run: `npm start` (Expo)
 
-Toast notifications are powered by `react-native-root-toast` and work in Expo Go without extra configuration.
+The app shows temporary trade messages using a built-in overlay notification.


### PR DESCRIPTION
## Summary
- add notification state and helper in `App.js`
- show notifications with an overlay instead of Toast
- document overlay notifications in the README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688411cac608832598c0981e2196ec02